### PR TITLE
Add complete Django sample project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,90 @@
+# Ejemplo Django UI
+
+Este repositorio contiene un proyecto **Django** minimalista pensado como base para desarrollar aplicaciones con una interfaz moderna y profesional. Se ha creado manualmente siguiendo las indicaciones del archivo `comentarios.txt` y todas las carpetas se encuentran directamente en la raíz del repositorio para facilitar el acceso.
+
+## Características principales
+
+- Proyecto Django llamado `ejemplo_django_ui`.
+- Una aplicación incluida: `pagina`.
+- Uso de **Bootstrap 5** y FontAwesome mediante CDN para dotar de un estilo atractivo sin necesidad de instalaciones adicionales.
+- Plantilla base con navegación responsive, sección hero animada, tarjetas de servicios y un sencillo formulario de contacto con validación básica en JavaScript.
+- Archivos estáticos separados en la carpeta `static/`.
+
+## Requisitos previos
+
+Para ejecutar este proyecto necesitas contar con **Python 3.12** o compatible y tener instalado Django. Puedes crear un entorno virtual para aislar las dependencias.
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install django
+```
+
+## Estructura del proyecto
+
+```
+manage.py
+comentarios.txt
+README.md
+/ejemplo_django_ui
+    __init__.py
+    settings.py
+    urls.py
+    wsgi.py
+    asgi.py
+/pagina
+    __init__.py
+    admin.py
+    apps.py
+    models.py
+    tests.py
+    views.py
+    urls.py
+    /migrations
+        __init__.py
+/templates
+    base.html
+    index.html
+/static
+    /css
+        styles.css
+    /js
+        scripts.js
+```
+
+### ¿Qué contiene cada archivo?
+
+- **manage.py**: script para ejecutar comandos de Django.
+- **ejemplo_django_ui/settings.py**: configuración principal del proyecto (base de datos SQLite, rutas de `templates` y `static`, etc.).
+- **ejemplo_django_ui/urls.py**: rutas globales que incluyen las de la app `pagina`.
+- **pagina/**: aquí vive la lógica de nuestra aplicación. En `views.py` se renderiza la página principal y en `urls.py` se define la ruta raíz.
+- **templates/**: archivos HTML. `base.html` define la estructura con navegación, contenido y footer, mientras que `index.html` hereda de esta base e incluye las secciones solicitadas.
+- **static/**: hoja de estilos CSS con efectos hover y archivo JS para manejar el formulario de contacto.
+
+## Cómo ejecutar el proyecto
+
+1. Activa tu entorno virtual y asegúrate de tener Django instalado.
+2. Sitúate en la raíz del repositorio (donde se encuentra `manage.py`).
+3. Ejecuta las migraciones y luego inicia el servidor de desarrollo:
+
+```bash
+python manage.py migrate
+python manage.py runserver
+```
+
+4. Abre `http://localhost:8000/` en tu navegador para ver la página de inicio.
+
+## Capturas de pantalla sugeridas
+
+Se recomienda añadir capturas de la sección hero, las tarjetas de servicios y la vista móvil para mostrar la adaptabilidad. Colócalas dentro de una carpeta `screenshots/` en el repositorio (no incluida inicialmente).
+
+## Tecnologías utilizadas
+
+- [Python](https://www.python.org/)
+- [Django](https://www.djangoproject.com/)
+- [Bootstrap 5](https://getbootstrap.com/) para estilos y componentes.
+- [FontAwesome](https://fontawesome.com/) para iconos.
+
+## Créditos y licencia
+
+El proyecto es de uso libre bajo la licencia MIT. Fue generado como ejemplo para otros desarrolladores que deseen una base sencilla pero con una interfaz moderna.

--- a/ejemplo_django_ui/__init__.py
+++ b/ejemplo_django_ui/__init__.py
@@ -1,0 +1,1 @@
+"""Paquete de configuración del proyecto ejemplo_django_ui."""

--- a/ejemplo_django_ui/asgi.py
+++ b/ejemplo_django_ui/asgi.py
@@ -1,0 +1,7 @@
+"""Configuración de ASGI para despliegues asíncronos."""
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ejemplo_django_ui.settings')
+
+application = get_asgi_application()

--- a/ejemplo_django_ui/settings.py
+++ b/ejemplo_django_ui/settings.py
@@ -1,0 +1,104 @@
+"""Configuración principal para el proyecto ejemplo_django_ui."""
+from pathlib import Path
+
+# Ruta base del proyecto
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+# Clave secreta para la instancia de desarrollo
+SECRET_KEY = 'django-insecure-reemplazar-por-clave-segura'
+
+# Indicamos que el modo debug está activado para desarrollo
+DEBUG = True
+
+# Permitimos todas las direcciones en desarrollo
+ALLOWED_HOSTS: list[str] = []
+
+# Aplicaciones instaladas en el proyecto
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    # Nuestra aplicación local
+    'pagina',
+]
+
+# Middleware que procesa cada request/respuesta
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+# URL base de la configuración
+ROOT_URLCONF = 'ejemplo_django_ui.urls'
+
+# Configuración de plantillas (templates)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        # Ruta a la carpeta de templates en la raíz
+        'DIRS': [BASE_DIR / 'templates'],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+# Configuración WSGI
+WSGI_APPLICATION = 'ejemplo_django_ui.wsgi.application'
+
+# Configuración de la base de datos (SQLite para simplicidad)
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
+    }
+}
+
+# Validadores de contraseña predeterminados de Django
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
+
+# Configuración de idioma y zona horaria
+LANGUAGE_CODE = 'es-es'
+TIME_ZONE = 'UTC'
+USE_I18N = True
+USE_TZ = True
+
+# Ruta para archivos estáticos
+STATIC_URL = '/static/'
+STATICFILES_DIRS = [BASE_DIR / 'static']
+
+# Ruta para archivos multimedia (si se usarán)
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
+
+# Modelo de usuario personalizado (si fuera necesario)
+# AUTH_USER_MODEL = 'app.UsuarioPersonalizado'
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/ejemplo_django_ui/urls.py
+++ b/ejemplo_django_ui/urls.py
@@ -1,0 +1,10 @@
+"""Definición de URLs principales del proyecto."""
+from django.contrib import admin
+from django.urls import path, include
+
+urlpatterns = [
+    # Ruta para el administrador de Django
+    path('admin/', admin.site.urls),
+    # Incluimos las URLs de la aplicación 'pagina'
+    path('', include('pagina.urls')),
+]

--- a/ejemplo_django_ui/wsgi.py
+++ b/ejemplo_django_ui/wsgi.py
@@ -1,0 +1,9 @@
+"""Punto de entrada para servidores WSGI."""
+import os
+from django.core.wsgi import get_wsgi_application
+
+# Establecemos la configuración de Django
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ejemplo_django_ui.settings')
+
+# Aplicación WSGI que utilizarán los servidores para lanzar el proyecto
+application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+Archivo de gestión principal para el proyecto Django ejemplo_django_ui.
+Permite ejecutar tareas administrativas como arrancar el servidor,
+crear migraciones, entre otras.
+
+Se reproduce la funcionalidad estándar del manage.py generado por
+``django-admin startproject`` pero escrito manualmente para este ejemplo.
+"""
+import os
+import sys
+
+# Establece la configuración predeterminada del proyecto para Django
+# indicándole en qué módulo se encuentran los ajustes.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ejemplo_django_ui.settings')
+
+
+def main() -> None:
+    """Punto de entrada para la utilidad de línea de comandos de Django."""
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        # Si Django no está instalado, se informa al usuario con claridad.
+        raise ImportError(
+            "No se pudo importar Django. Asegúrate de que esté instalado y "
+            "disponible en tu PYTHONPATH y de haber activado un entorno virtual."
+        ) from exc
+
+    # Llama a la utilidad de Django pasándole los argumentos recibidos.
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == '__main__':
+    # Ejecuta la función principal cuando el archivo se invoca directamente
+    main()

--- a/pagina/__init__.py
+++ b/pagina/__init__.py
@@ -1,0 +1,1 @@
+"""Paquete que contiene la aplicación pagina."""

--- a/pagina/admin.py
+++ b/pagina/admin.py
@@ -1,0 +1,6 @@
+"""Registro de modelos en el administrador de Django."""
+from django.contrib import admin
+
+# Aquí se podrían registrar modelos en el futuro
+# from .models import MiModelo
+# admin.site.register(MiModelo)

--- a/pagina/apps.py
+++ b/pagina/apps.py
@@ -1,0 +1,8 @@
+"""Configuración de la aplicación pagina."""
+from django.apps import AppConfig
+
+
+class PaginaConfig(AppConfig):
+    """Configuración general de la app."""
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'pagina'

--- a/pagina/migrations/__init__.py
+++ b/pagina/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Modulo de migraciones de la app."""

--- a/pagina/models.py
+++ b/pagina/models.py
@@ -1,0 +1,5 @@
+"""Modelos de la aplicación pagina."""
+from django.db import models
+
+# En este ejemplo no definimos modelos, pero el archivo se deja preparado
+# para futuras expansiones.

--- a/pagina/tests.py
+++ b/pagina/tests.py
@@ -1,0 +1,4 @@
+"""Pruebas de la aplicación pagina."""
+from django.test import TestCase
+
+# Aquí se pueden añadir tests para las vistas y modelos

--- a/pagina/urls.py
+++ b/pagina/urls.py
@@ -1,0 +1,7 @@
+"""Definición de rutas para la aplicación pagina."""
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.index, name='index'),
+]

--- a/pagina/views.py
+++ b/pagina/views.py
@@ -1,0 +1,7 @@
+"""Vistas de la aplicación pagina."""
+from django.shortcuts import render
+
+
+def index(request):
+    """Renderiza la página de inicio."""
+    return render(request, 'index.html')

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,13 @@
+/* Estilos personalizados para el proyecto */
+body {
+    scroll-behavior: smooth;
+}
+
+/* efecto para las tarjetas de servicios */
+.servicio-card {
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+.servicio-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 16px rgba(0,0,0,0.2);
+}

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -1,0 +1,14 @@
+// Archivo JS para añadir interactividad
+// En este ejemplo se previene el envío real del formulario de contacto
+// mostrando un mensaje en consola.
+
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.querySelector('#contacto form');
+    if (form) {
+        form.addEventListener('submit', (e) => {
+            e.preventDefault();
+            console.log('Formulario enviado (demo)');
+            alert('Gracias por tu mensaje!');
+        });
+    }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Ejemplo Django UI{% endblock %}</title>
+    <!-- Bootstrap 5 via CDN para estilos modernos -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Íconos opcionales -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
+    <!-- Nuestra hoja de estilos personalizada -->
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}">
+</head>
+<body>
+    <!-- Navegación principal -->
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+        <div class="container">
+            <a class="navbar-brand" href="#">Django UI</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item"><a class="nav-link active" href="#">Inicio</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#servicios">Servicios</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#contacto">Contacto</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Contenido principal de cada página -->
+    <main class="pt-5">
+        {% block content %}{% endblock %}
+    </main>
+
+    <!-- Footer moderno -->
+    <footer class="bg-dark text-white text-center py-4 mt-5">
+        <p class="mb-0">&copy; 2024 Ejemplo Django UI</p>
+    </footer>
+
+    <!-- Scripts de Bootstrap y adicionales -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{% static 'js/scripts.js' %}"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,74 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}Inicio - Ejemplo Django UI{% endblock %}
+
+{% block content %}
+<!-- Hero Section -->
+<section class="vh-100 d-flex align-items-center bg-light" id="hero">
+    <div class="container text-center">
+        <h1 class="display-4 fw-bold">Bienvenido a un ejemplo moderno con Django</h1>
+        <p class="lead">Proyecto base para iniciar tus desarrollos.</p>
+        <a href="#servicios" class="btn btn-primary btn-lg mt-3">Ver más</a>
+    </div>
+</section>
+
+<!-- Services Section -->
+<section class="py-5" id="servicios">
+    <div class="container">
+        <h2 class="text-center mb-4">Servicios</h2>
+        <div class="row g-4">
+            <div class="col-md-4">
+                <!-- Card with hover effect -->
+                <div class="card h-100 shadow-sm border-0 servicio-card">
+                    <div class="card-body text-center">
+                        <i class="fas fa-bolt fa-3x mb-3 text-primary"></i>
+                        <h5 class="card-title">Rápido</h5>
+                        <p class="card-text">Aplicaciones ágiles y eficientes.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="card h-100 shadow-sm border-0 servicio-card">
+                    <div class="card-body text-center">
+                        <i class="fas fa-mobile-alt fa-3x mb-3 text-primary"></i>
+                        <h5 class="card-title">Responsive</h5>
+                        <p class="card-text">Diseños adaptados a cualquier dispositivo.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="card h-100 shadow-sm border-0 servicio-card">
+                    <div class="card-body text-center">
+                        <i class="fas fa-lock fa-3x mb-3 text-primary"></i>
+                        <h5 class="card-title">Seguro</h5>
+                        <p class="card-text">Buenas prácticas en seguridad web.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- Contact Section -->
+<section class="py-5 bg-light" id="contacto">
+    <div class="container">
+        <h2 class="text-center mb-4">Contacto</h2>
+        <form class="mx-auto" style="max-width: 600px;">
+            <div class="mb-3">
+                <label for="nombre" class="form-label">Nombre</label>
+                <input type="text" class="form-control" id="nombre" required>
+            </div>
+            <div class="mb-3">
+                <label for="email" class="form-label">Correo electrónico</label>
+                <input type="email" class="form-control" id="email" required>
+            </div>
+            <div class="mb-3">
+                <label for="mensaje" class="form-label">Mensaje</label>
+                <textarea class="form-control" id="mensaje" rows="4" required></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Enviar</button>
+        </form>
+    </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Django project with manage.py, project package and pagina app
- create templates and static assets for a modern UI
- document usage and structure in README

## Testing
- `python3 -m py_compile manage.py ejemplo_django_ui/*.py pagina/*.py pagina/migrations/*.py`
- `python3 manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686eb50a98e0832d87ccdafc67d26cdc