### PR TITLE
Add dark mode and guided docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Este repositorio contiene un proyecto **Django** minimalista pensado como base p
 
 - Proyecto Django llamado `ejemplo_django_ui`.
 - Una aplicación incluida: `pagina`.
-- Uso de **Bootstrap 5** y FontAwesome mediante CDN para dotar de un estilo atractivo sin necesidad de instalaciones adicionales.
-- Plantilla base con navegación responsive, sección hero animada, tarjetas de servicios y un sencillo formulario de contacto con validación básica en JavaScript.
-- Archivos estáticos separados en la carpeta `static/`.
+- Uso de **Bootstrap 5** y FontAwesome mediante CDN para un aspecto moderno.
+- Tarjetas de servicios con efecto "levantarse" al posar el mouse.
+- Botón de **modo oscuro** que invierte los colores de la página.
+- Colores principales verde agua y morado, definidos en `static/css/styles.css`.
+- Script `run.py` para iniciar el servidor y abrir el navegador automáticamente.
 
 ## Requisitos previos
 
@@ -54,6 +56,9 @@ README.md
 
 ### ¿Qué contiene cada archivo?
 
+Para un recorrido paso a paso revisa también `README2.md` donde se explica
+qué archivo abrir a continuación para aprender del proyecto.
+
 - **manage.py**: script para ejecutar comandos de Django.
 - **ejemplo_django_ui/settings.py**: configuración principal del proyecto (base de datos SQLite, rutas de `templates` y `static`, etc.).
 - **ejemplo_django_ui/urls.py**: rutas globales que incluyen las de la app `pagina`.
@@ -65,14 +70,17 @@ README.md
 
 1. Activa tu entorno virtual y asegúrate de tener Django instalado.
 2. Sitúate en la raíz del repositorio (donde se encuentra `manage.py`).
-3. Ejecuta las migraciones y luego inicia el servidor de desarrollo:
+3. Ejecuta las migraciones:
 
 ```bash
 python manage.py migrate
-python manage.py runserver
 ```
 
-4. Abre `http://localhost:8000/` en tu navegador para ver la página de inicio.
+4. Finalmente lanza el script `run.py` para que abra el navegador automáticamente:
+
+```bash
+python run.py
+```
 
 ## Capturas de pantalla sugeridas
 
@@ -84,6 +92,12 @@ Se recomienda añadir capturas de la sección hero, las tarjetas de servicios y 
 - [Django](https://www.djangoproject.com/)
 - [Bootstrap 5](https://getbootstrap.com/) para estilos y componentes.
 - [FontAwesome](https://fontawesome.com/) para iconos.
+
+## Recorrido guiado
+
+Si quieres profundizar en el código fuente sigue las indicaciones de
+`README2.md`, donde se propone un orden de lectura de los archivos
+para comprender mejor el proyecto.
 
 ## Créditos y licencia
 

--- a/README2.md
+++ b/README2.md
@@ -1,0 +1,28 @@
+# Recorrido guiado del proyecto
+
+Este documento complementa el `README.md` tradicional. La idea es
+que puedas explorar los archivos poco a poco para entender la
+estructura.
+
+1. **`manage.py`**
+   - Punto de entrada para comandos de Django. Lee los comentarios
+     de este archivo para saber cómo se configura la utilidad.
+2. **`ejemplo_django_ui/settings.py`**
+   - Explica cómo está configurado Django: base de datos, rutas de
+     plantillas y archivos estáticos.
+3. **`ejemplo_django_ui/urls.py`**
+   - Aquí verás cómo se enrutan las peticiones a la app `pagina`.
+4. **`pagina/views.py`** y **`pagina/urls.py`**
+   - Muestran la función de vista principal y la URL asociada.
+5. **`templates/base.html`**
+   - Plantilla principal. Observa los comentarios para entender la
+     estructura HTML y el botón de modo oscuro.
+6. **`templates/index.html`**
+   - Página de inicio que hereda de `base.html` y define las secciones
+     hero, servicios y contacto.
+7. **`static/css/styles.css`** y **`static/js/scripts.js`**
+   - Archivos de estilos y scripts. Revisa los comentarios para conocer
+     cómo se implementan los colores y el modo oscuro.
+
+Cuando termines de revisar un archivo vuelve a esta guía para continuar
+con el siguiente. ¡Disfruta el aprendizaje!

--- a/run.py
+++ b/run.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Script auxiliar para ejecutar el servidor y abrir el navegador."""
+
+import subprocess
+import webbrowser
+from threading import Timer
+
+
+def main() -> None:
+    """Inicia el servidor Django y abre la página principal."""
+    # Ejecutamos ``manage.py runserver`` en un subproceso
+    proc = subprocess.Popen(["python", "manage.py", "runserver"])
+
+    # Tras unos segundos, abrimos el navegador por defecto
+    Timer(2, lambda: webbrowser.open("http://127.0.0.1:8000/")).start()
+
+    try:
+        proc.wait()
+    except KeyboardInterrupt:
+        proc.terminate()
+
+
+if __name__ == "__main__":
+    main()

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,13 +1,61 @@
-/* Estilos personalizados para el proyecto */
+/*
+Estilos personalizados para el proyecto.
+
+Se definen variables CSS para los colores principales de la interfaz.
+La combinación solicitada es verde agua y morado.
+*/
+
+:root {
+    /* Verde agua */
+    --color-primario: #1abc9c;
+    /* Morado intenso */
+    --color-secundario: #6f42c1;
+}
+
+/* Comportamiento global de desplazamiento suave */
 body {
     scroll-behavior: smooth;
 }
 
-/* efecto para las tarjetas de servicios */
+/* Color personalizado para la barra de navegación */
+.navbar-dark.bg-dark {
+    background-color: var(--color-secundario) !important;
+}
+
+/* Botones primarios con nuestro verde agua */
+.btn-primary {
+    background-color: var(--color-primario);
+    border-color: var(--color-primario);
+}
+.btn-primary:hover {
+    background-color: #17a589; /* tono ligeramente más oscuro */
+    border-color: #17a589;
+}
+
+/*
+Modo oscuro. Cuando el <body> tenga la clase "dark-mode",
+se invierten los colores para no cansar la vista.
+*/
+body.dark-mode {
+    background-color: #121212;
+    color: #f8f9fa;
+}
+body.dark-mode .navbar-dark.bg-dark {
+    background-color: #000 !important;
+}
+body.dark-mode .card {
+    background-color: #1f1f1f;
+    color: #fff;
+}
+
+/*
+Efecto para las tarjetas de servicios. Al pasar el mouse se elevan levemente
+y proyectan una sombra para dar la impresión de "levantarse".
+*/
 .servicio-card {
     transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 .servicio-card:hover {
-    transform: translateY(-5px);
+    transform: translateY(-8px);
     box-shadow: 0 8px 16px rgba(0,0,0,0.2);
 }

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -2,13 +2,30 @@
 // En este ejemplo se previene el envío real del formulario de contacto
 // mostrando un mensaje en consola.
 
+/*
+Archivo JavaScript principal para la página.
+
+Se encarga de dos tareas:
+1. Mostrar un mensaje cuando el usuario envía el formulario de contacto.
+2. Activar o desactivar el modo oscuro al presionar un botón.
+*/
+
 document.addEventListener('DOMContentLoaded', () => {
+    // --- Manejo del formulario de contacto ---
     const form = document.querySelector('#contacto form');
     if (form) {
         form.addEventListener('submit', (e) => {
             e.preventDefault();
             console.log('Formulario enviado (demo)');
             alert('Gracias por tu mensaje!');
+        });
+    }
+
+    // --- Funcionalidad de modo oscuro ---
+    const toggle = document.getElementById('btn-dark-mode');
+    if (toggle) {
+        toggle.addEventListener('click', () => {
+            document.body.classList.toggle('dark-mode');
         });
     }
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,6 +26,8 @@
                     <li class="nav-item"><a class="nav-link" href="#servicios">Servicios</a></li>
                     <li class="nav-item"><a class="nav-link" href="#contacto">Contacto</a></li>
                 </ul>
+                <!-- Botón para activar el modo oscuro -->
+                <button id="btn-dark-mode" class="btn btn-light btn-sm ms-3" type="button">Modo oscuro</button>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
## Summary
- refine color scheme with aqua/ purple variables
- add dark mode button and JS handler
- provide run.py script to start server and open browser
- improve README and add README2 walkthrough

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686ebc1350d4832d818179fe6c4e0b84